### PR TITLE
utf8 -> utf8mb4

### DIFF
--- a/docker/mysql/my.cnf
+++ b/docker/mysql/my.cnf
@@ -1,6 +1,6 @@
 [mysqld]
-character-set-server=utf8
-collation-server=utf8_general_ci
+character-set-server=utf8mb4
+collation-server=utf8mb4_0900_as_cs
 
 [client]
-default-character-set=utf8
+default-character-set=utf8mb4


### PR DESCRIPTION
- https://tmtms.hatenablog.com/entry/201805/mysql-innovation-day-tokyo
- https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html
- https://dev.mysql.com/doc/refman/5.6/ja/show-collation.html
- https://www.slideshare.net/rkajiyama/db-tech-showcase-2017-tokyo-d31-mysql-80


  |  
-- | --
bin | コードのまま
general | MySQL独自規則
unicode | Unicode 4.0.0
unicode_0520 | Unicode 5.2.0
0900 | Unicode 9.0.0
ja_0900 | Unicode 9.0.0 + 日本語

  |  
-- | --
ai | Accent Insensitive アクセント違いは同じ文字
as | Accent Sensitive アクセント違いは異なる文字
ci | Case Insensitive 大文字小文字は同じ文字
cs | Case Sensitive 大文字小文字は異なる文字
ks | Kana Sensitive カタカナひらがなは異なる文字